### PR TITLE
Fix autoloading issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The included PingFederate configuration archive allows a single instance of Ping
 
 * PingFederate 8.x or later
 * PingFederate Agentless Integration Kit 1.5 or later
-* PHP 7.0 or later
+* PHP 7.0 or later with the php_curl extension installed
 
 ### Browser compatibility
 

--- a/sample-applications/AgentlessIdPSample/IdpSampleApp/Configuration/ConfigurationManager.php
+++ b/sample-applications/AgentlessIdPSample/IdpSampleApp/Configuration/ConfigurationManager.php
@@ -1,7 +1,7 @@
 <?php
 
-// loads app configuration according to idp-adpater-configuration.ini file for each request
-// any changes to configuration through UI will invoke save and reload of app with new configuraiton
+// loads app configuration according to idp-adapter-configuration.ini file for each request
+// any changes to configuration through UI will invoke save and reload of app with new configuration
 
 class ConfigurationManager
 {

--- a/sample-applications/AgentlessIdPSample/app/index.php
+++ b/sample-applications/AgentlessIdPSample/app/index.php
@@ -12,8 +12,22 @@
 
 	$modules = [ROOT, APP, CONFIGURATION, CONTROLLER, EXCEPTION, LIB, MODEL, VIEW];
 
+    /**
+     * Custom loader to look for CamelCased filenames names rather than the default
+     * of lower cased filenames
+     */
+    function custom_load($class)
+    {
+        $include_path = explode(PATH_SEPARATOR, get_include_path());
+        foreach ($include_path as $folder) {
+            if (count(glob("$folder$class.php")) > 0) {
+                include $folder . $class . ".php";
+            }
+        }
+    }
+
 	set_include_path(get_include_path() . PATH_SEPARATOR . implode(PATH_SEPARATOR, $modules));
-	spl_autoload_register('spl_autoload', false);
+	spl_autoload_register('custom_load', false);
 
 	$configuration = new ConfigurationManager();
 	$configuration->loadConfiguration();

--- a/sample-applications/AgentlessSPSample/app/index.php
+++ b/sample-applications/AgentlessSPSample/app/index.php
@@ -12,8 +12,22 @@
 
 	$modules = [ROOT, APP, CONFIGURATION, CONTROLLER, EXCEPTION, LIB, MODEL, VIEW];
 
+    /**
+     * Custom loader to look for CamelCased filenames names rather than the default
+     * of lower cased filenames
+     */
+    function custom_load($class)
+    {
+        $include_path = explode(PATH_SEPARATOR, get_include_path());
+        foreach ($include_path as $folder) {
+            if (count(glob("$folder$class.php")) > 0) {
+                include $folder . $class . ".php";
+            }
+        }
+    }
+
 	set_include_path(get_include_path() . PATH_SEPARATOR . implode(PATH_SEPARATOR, $modules));
-	spl_autoload_register('spl_autoload', false);
+	spl_autoload_register('custom_load', false);
 
 	$spAdapterConfiguration = new ConfigurationManager();
 	$spAdapterConfiguration->loadConfiguration();


### PR DESCRIPTION
PHP, by default will look for a class by lowercasing the classname and looking for that file with a .inc or .php extension. On some systems, classes could not be located. This fix will looks for the classname as is (not lowercased) as that is the file structure laid out for this project.